### PR TITLE
revive kernel prefix test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6d48398b3112efb733b254edede4b7f3262c28bd19f665b64ef1acf6ec5cd74f
 
 build:
-  number: 0
+  number: 1
   script:
     - pip install --no-deps .
     - python -m ipykernel install --prefix $PREFIX  # [not win]

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,0 +1,4 @@
+@echo off
+
+:: Install kernelspec at post-link because conda doesn't substitute Windows paths correctly in JSON files
+"%PREFIX%"\Python.exe -m ipykernel install --sys-prefix > NUL 2>&1 && if errorlevel 1 exit 1

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,16 @@
+import json
+import os
+import sys
+
+
+py_major = sys.version_info[0]
+specfile = os.path.join(os.environ['PREFIX'], 'share', 'jupyter', 'kernels',
+                        'python{}'.format(py_major), 'kernel.json')
+with open(specfile, 'r') as fh:
+    spec = json.load(fh)
+
+
+if spec['argv'][0] != sys.executable:
+    raise ValueError('The specfile seems to have the wrong prefix. \n'
+                     'Specfile: {}; Expected: {};'
+                     ''.format(spec['argv'][0], sys.executable))


### PR DESCRIPTION
rebases #7 on master, which I *believe* fixes the issue, but the test will let is know.

If it still needs fixing, we can add a post-link workaround for Windows to re-render the kernelspec install at install time.

closes #6
closes #7