### PR TITLE
Testing: Delete post-link.bat

### DIFF
--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,4 +1,0 @@
-@echo off
-
-:: Install kernelspec at post-link because conda doesn't substitute Windows paths correctly in JSON files
-"%PREFIX%"\Python.exe -m ipykernel install --sys-prefix > NUL 2>&1 && if errorlevel 1 exit 1

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -10,7 +10,7 @@ with open(specfile, 'r') as fh:
     spec = json.load(fh)
 
 
-if spec['argv'][0] != sys.executable:
+if spec['argv'][0].replace('\\', '/') != sys.executable.replace('\\', '/'):
     raise ValueError('The specfile seems to have the wrong prefix. \n'
                      'Specfile: {}; Expected: {};'
                      ''.format(spec['argv'][0], sys.executable))


### PR DESCRIPTION
testing whether the issue this works around has been fixed in conda-build by now
this introduces an ordering dependency between this package and its dependencies
if dependencies are not linked when this script tries to run, the imports may fail
ref https://github.com/ContinuumIO/anaconda-issues/issues/8087#issuecomment-369367450