### PR TITLE
MAINT: Remove post-link for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About ipykernel
 ===============
 
-Home: http://ipython.org
+Home: https://ipython.org
 
 Package license: BSD 3-clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,11 +9,10 @@ source:
   sha256: 699103c8e64886e3ec7053f2a6aa83bb90426063526f63a818732ff385202bad
 
 build:
-  number: 0
+  number: 1
   script:
     - "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
-    - python -m ipykernel install --prefix $PREFIX  # [not win]
-    - python -m ipykernel install --prefix %PREFIX%  # [win]
+    - python -m ipykernel install --prefix {{ PREFIX }}
 
 requirements:
   build:

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,4 +1,0 @@
-@echo off
-
-:: Install kernelspec at post-link because conda doesn't substitute Windows paths correctly in JSON files
-"%PREFIX%"\Python.exe -m ipykernel install --sys-prefix > NUL 2>&1 && if errorlevel 1 exit 1

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -10,7 +10,7 @@ with open(specfile, 'r') as fh:
     spec = json.load(fh)
 
 
-if spec['argv'][0] != sys.executable:
+if spec['argv'][0].replace('\\', '/') != sys.executable.replace('\\', '/'):
     raise ValueError('The specfile seems to have the wrong prefix. \n'
                      'Specfile: {}; Expected: {};'
                      ''.format(spec['argv'][0], sys.executable))


### PR DESCRIPTION
Supersedes #25 as it seems to have gone stale.

I've tested running spyder in an environment with this installed. seems to work. 

This makes it one step closer to a no-arch package.


Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
