### PR TITLE
add tests and metadata

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -6,3 +6,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil
+numpy:
+- '1.9'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About ipykernel
 
 Home: https://ipython.org
 
-Package license: BSD 3-clause
+Package license: BSD-3-Clause
 
 Feedstock license: BSD 3-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ about:
   license_file: COPYING.md
   summary: IPython Kernel for Jupyter
   dev_url: https://github.com/ipython/ipykernel
-  docs_url: https://ipython.readthedocs.io
+  doc_url: https://ipython.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,41 +9,53 @@ source:
   sha256: 3e0ffdf545c0bf80d9dab6523ec6829831408c474772487aeb6eb9f0348b6a1e
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script:
     - "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
     - python -m ipykernel install --prefix {{ PREFIX }}
 
 requirements:
-  build:
-    - pip
-    - python >=3
-    - jupyter_client
-    - ipython >=4.0
-    - tornado >=4.0
-  run:
-    - python >=3
+  host:
     - ipython >=5.0
-    - traitlets >=4.1
     - jupyter_client
+    - pip
+    - python >=3.4
+  run:
+    - ipython >=5.0
+    - jupyter_client
+    - python >=3.4
     - tornado >=4.0
+    - traitlets >=4.1
 
 test:
+  requires:
+    - curio  # [unix]
+    - matplotlib
+    - nose
+    - numpy
+    - pytest
+    - trio
   imports:
     - ipykernel
+  commands:
+    - jupyter kernelspec list
+    - pytest --pyargs ipykernel
 
 about:
   home: https://ipython.org
-  license: BSD 3-clause
+  license: BSD-3-Clause
   license_file: COPYING.md
   summary: IPython Kernel for Jupyter
+  dev_url: https://github.com/ipython/ipykernel
+  docs_url: https://ipython.readthedocs.io
 
 extra:
   recipe-maintainers:
+    - blink1073
+    - bollwyvl
+    - Carreau
     - jakirkham
-    - pelson
     - minrk
     - ocefpaf
-    - blink1073
-    - Carreau
+    - pelson


### PR DESCRIPTION
This just carries through the stuff we did over on ipython-feedstock. Having tests is doubly important on noarch packages, but we won't know about install/build bugs for other platforms. What can you do?

Checklist
* [x] Used a fork of the feedstock to propose changes
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
