### PR TITLE
Make the ipython-kernels arch dependent again.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,7 @@ source:
   sha256: 0fc0bf97920d454102168ec2008620066878848fcfca06c22b669696212e292f
 
 build:
-  number: 0
-  noarch: python
+  number: 1
   script:
     - "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
     - python -m ipykernel install --prefix {{ PREFIX }}

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,0 +1,7 @@
+@echo off
+
+:: Install kernelspec at post-link because conda doesn't substitute Windows paths correctly in JSON files
+:: One error conda makes is that it doesn't remove the `bin` folder from the python path.
+:: Second, it doesn't add the `.exe` extention.
+:: See discussion in https://github.com/conda-forge/ipykernel-feedstock/issues/37
+"%PREFIX%"\Python.exe -m ipykernel install --sys-prefix > NUL 2>&1 && if errorlevel 1 exit 1


### PR DESCRIPTION
Fixes  #37

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
