### PR TITLE
Pypy37

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -24,6 +24,10 @@ jobs:
         CONFIG: linux_64_numpy1.18python3.6.____73_pypy
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_numpy1.19python3.7.____73_pypy:
+        CONFIG: linux_64_numpy1.19python3.7.____73_pypy
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_numpy1.19python3.9.____cpython:
         CONFIG: linux_64_numpy1.19python3.9.____cpython
         UPLOAD_PACKAGES: 'True'

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -20,6 +20,9 @@ jobs:
       osx_64_numpy1.18python3.6.____73_pypy:
         CONFIG: osx_64_numpy1.18python3.6.____73_pypy
         UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.19python3.7.____73_pypy:
+        CONFIG: osx_64_numpy1.19python3.7.____73_pypy
+        UPLOAD_PACKAGES: 'True'
       osx_64_numpy1.19python3.9.____cpython:
         CONFIG: osx_64_numpy1.19python3.9.____cpython
         UPLOAD_PACKAGES: 'True'

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -61,10 +61,10 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build==3.18.11 conda "conda-forge-ci-setup=3" pip' # Optional
+        packageSpecs: 'python=3.6 conda-build conda "conda-forge-ci-setup=3" pip' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
-      displayName: Install conda-build==3.18.11 and activate environment
+      displayName: Install conda-build and activate environment
 
     - script: set PYTHONUNBUFFERED=1
       displayName: Set PYTHONUNBUFFERED

--- a/.ci_support/linux_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.6.____cpython.yaml
@@ -17,5 +17,7 @@ python:
 target_platform:
 - linux-64
 zip_keys:
+- - cdt_name
+  - docker_image
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.7.____cpython.yaml
@@ -17,5 +17,7 @@ python:
 target_platform:
 - linux-64
 zip_keys:
+- - cdt_name
+  - docker_image
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.8.____cpython.yaml
@@ -17,5 +17,7 @@ python:
 target_platform:
 - linux-64
 zip_keys:
+- - cdt_name
+  - docker_image
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.18python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.6.____73_pypy.yaml
@@ -17,5 +17,7 @@ python:
 target_platform:
 - linux-64
 zip_keys:
+- - cdt_name
+  - docker_image
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.7.____73_pypy.yaml
@@ -17,5 +17,7 @@ python:
 target_platform:
 - linux-64
 zip_keys:
+- - cdt_name
+  - docker_image
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.7.____73_pypy.yaml
@@ -1,11 +1,11 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+cdt_name:
+- cos6
 channel_sources:
-- conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
-macos_machine:
-- arm64-apple-darwin20.0.0
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
 numpy:
 - '1.19'
 pin_run_as_build:
@@ -13,9 +13,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.7.* *_73_pypy
 target_platform:
-- osx-arm64
+- linux-64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
@@ -17,5 +17,7 @@ python:
 target_platform:
 - linux-64
 zip_keys:
+- - cdt_name
+  - docker_image
 - - python
   - numpy

--- a/.ci_support/linux_aarch64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.7.____73_pypy.yaml
@@ -1,11 +1,15 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-macos_machine:
-- arm64-apple-darwin20.0.0
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
 numpy:
 - '1.19'
 pin_run_as_build:
@@ -13,9 +17,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.7.* *_73_pypy
 target_platform:
-- osx-arm64
+- linux-aarch64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/linux_ppc64le_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.19python3.7.____73_pypy.yaml
@@ -1,11 +1,11 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
-macos_machine:
-- arm64-apple-darwin20.0.0
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
 numpy:
 - '1.19'
 pin_run_as_build:
@@ -13,9 +13,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.7.* *_73_pypy
 target_platform:
-- osx-arm64
+- linux-ppc64le
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/migrations/pypy37.yaml
+++ b/.ci_support/migrations/pypy37.yaml
@@ -1,0 +1,29 @@
+migrator_ts: 1608144114
+__migrator:
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.6.* *_cpython
+            - 3.7.* *_cpython
+            - 3.8.* *_cpython
+            - 3.9.* *_cpython
+            - 3.6.* *_73_pypy
+            - 3.7.* *_73_pypy  # new entry
+    paused: false
+    longterm: True
+    pr_limit: 50
+    exclude:
+      # this shouldn't attempt to modify the python feedstocks
+      - python
+      - pypy3.6
+      - pypy-meta
+
+python:                # [not (win or arm64)]
+  - 3.7.* *_73_pypy    # [not (win or arm64)]
+# additional entries to add for zip_keys
+numpy:                 # [not (win or arm64)]
+  - 1.19               # [not (win or arm64)]
+python_impl:           # [not (win or arm64)]
+  - pypy               # [not (win or arm64)]

--- a/.ci_support/osx_64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.7.____73_pypy.yaml
@@ -1,11 +1,11 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.9'
 channel_sources:
-- conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 numpy:
 - '1.19'
 pin_run_as_build:
@@ -13,9 +13,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.7.* *_73_pypy
 target_platform:
-- osx-arm64
+- osx-64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 macos_machine:

--- a/.drone.yml
+++ b/.drone.yml
@@ -124,6 +124,37 @@ steps:
 
 ---
 kind: pipeline
+name: linux_aarch64_numpy1.19python3.7.____73_pypy
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: quay.io/condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_numpy1.19python3.7.____73_pypy
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
 name: linux_aarch64_numpy1.19python3.9.____cpython
 
 platform:

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -45,8 +45,12 @@ fi
 if [ -z "${DOCKER_IMAGE}" ]; then
     SHYAML_INSTALLED="$(shyaml -h || echo NO)"
     if [ "${SHYAML_INSTALLED}" == "NO" ]; then
-        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
-        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
+        DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
+        if [ "${DOCKER_IMAGE}" = "" ]; then
+            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        fi
     else
         DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
     fi
@@ -64,8 +68,8 @@ fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ matrix:
       os: linux
       arch: ppc64le
 
+    - env: CONFIG=linux_ppc64le_numpy1.19python3.7.____73_pypy UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
     - env: CONFIG=linux_ppc64le_numpy1.19python3.9.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_numpy1.19python3.7.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=458&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ipykernel-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.19python3.7.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_numpy1.19python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=458&branchName=master">
@@ -109,6 +116,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=458&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ipykernel-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.18python3.6.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.19python3.7.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=458&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ipykernel-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.19python3.7.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -147,6 +161,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_ppc64le_numpy1.19python3.7.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=458&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ipykernel-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.19python3.7.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_ppc64le_numpy1.19python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=458&branchName=master">
@@ -179,6 +200,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=458&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ipykernel-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.18python3.6.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.19python3.7.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=458&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ipykernel-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.19python3.7.____73_pypy" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 697103d218e9a8828025af7986e033c89e0b36e2b6eb84a5bda4739b9a27f3cb
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<34]
   script:
     - {{ PYTHON }} setup.py bdist_wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,9 @@ requirements:
     - python
     - tornado >=4.2
     - traitlets >=4.1
+    # pyzmq is a run-dep of jupyter_client;
+    # temporary pin since v21 breaks pypy
+    - pyzmq <21
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: e20ceb7e52cb4d250452e1230be76e0b2323f33bd46c6b2bc7abb6601740e182
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<34]
   script:
     - {{ PYTHON }} setup.py bdist_wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.4.2" %}
+{% set version = "5.4.3" %}
 
 package:
   name: ipykernel
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/ipykernel/ipykernel-{{ version }}.tar.gz
-  sha256: e20ceb7e52cb4d250452e1230be76e0b2323f33bd46c6b2bc7abb6601740e182
+  sha256: 697103d218e9a8828025af7986e033c89e0b36e2b6eb84a5bda4739b9a27f3cb
 
 build:
   number: 1


### PR DESCRIPTION
#72 and #73 hang on pypy, even though that was not the case on master [two weeks ago](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=259197&view=results).

@mattip tested it and [thinks](https://github.com/conda-forge/ipykernel-feedstock/pull/72#issuecomment-764531056) it's to do with `pyzmq`, which gets pulled in through `jupyter_client` and [indeed](https://github.com/conda-forge/pyzmq-feedstock/commits/master) has seen updates since then. Try pinnning it `<21` and see if that helps

Edit: it does, but only when combined the version bump from #73.

Closes #72 
Closes #73