### PR TITLE
Add upper bound to dependency versions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Carreau @blink1073 @bollwyvl @jakirkham @minrk @ocefpaf @pelson
+* @Carreau @blink1073 @bollwyvl @davidbrochart @jakirkham @minrk @ocefpaf @pelson

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Feedstock Maintainers
 * [@Carreau](https://github.com/Carreau/)
 * [@blink1073](https://github.com/blink1073/)
 * [@bollwyvl](https://github.com/bollwyvl/)
+* [@davidbrochart](https://github.com/davidbrochart/)
 * [@jakirkham](https://github.com/jakirkham/)
 * [@minrk](https://github.com/minrk/)
 * [@ocefpaf](https://github.com/ocefpaf/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: a4f51c53c7be3f93d75c25839183fa2dfa24908fc650dfd023b276c7a080dc73
 
 build:
-  number: 0
+  number: 1
   # TODO: restore pypy builds https://github.com/conda-forge/ipykernel-feedstock/issues/85
   skip: true  # [py<37 or python_impl == "pypy"]
   script:
@@ -25,25 +25,25 @@ requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - ipython >=5.0                          # [build_platform != target_platform]
-    - jupyter_client                         # [build_platform != target_platform]
+    - ipython >=5.0,<8.0                     # [build_platform != target_platform]
+    - jupyter_client <7.0                    # [build_platform != target_platform]
   {% endif %}
   host:
-    - debugpy >=1
-    - ipython >=7.23.1
-    - jupyter_client
+    - debugpy >=1,<2.0
+    - ipython >=7.23.1,<8.0
+    - jupyter_client <7.0
     - pip
     - python
   run:
     - appnope  # [osx]
-    - debugpy >=1
+    - debugpy >=1,<2.0
     - importlib-metadata <4  # [py<38]
-    - ipython >=7.23.1
-    - jupyter_client
+    - ipython >=7.23.1,<8.0
+    - jupyter_client <7.0
     - matplotlib-inline >=0.1.0,<0.2.0
     - python
-    - tornado >=4.2
-    - traitlets >=4.1.0
+    - tornado >=4.2,<7.0
+    - traitlets >=4.1.0,<6.0
 
 test:
   requires:
@@ -87,3 +87,4 @@ extra:
     - minrk
     - ocefpaf
     - pelson
+    - davidbrochart


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
As done in https://github.com/ipython/ipykernel/pull/714.
<!--
Please add any other relevant info below:
-->
@conda-forge-admin, please rerender